### PR TITLE
Move `renderText()` outside of `observe()` in callr examples

### DIFF
--- a/callr/callr_example.R
+++ b/callr/callr_example.R
@@ -12,6 +12,7 @@ server <- function(input, output, session) {
   # initiate reactive values
   bg_proc <- reactiveVal(NULL)
   check_finished <- reactiveVal(FALSE)
+  table_dt <- reactiveVal(NULL)
   
   # set whatever arguments you want to use
   some_argument <- "virginica"
@@ -44,6 +45,7 @@ server <- function(input, output, session) {
     # update reactive vals
     bg_proc(p)
     check_finished(TRUE)
+    table_dt(NULL)
   })
   
   # this part can be useful if you want to update your UI during the process
@@ -71,7 +73,10 @@ server <- function(input, output, session) {
     }
     
   })
-  
+
+  # Display the table data
+  output$result_table <- renderTable(table_dt())
+
 }
 
 shinyApp(ui = ui, server = server)

--- a/callr/callr_example.R
+++ b/callr/callr_example.R
@@ -3,8 +3,8 @@ library(callr)
 
 ui <- fluidPage(
   titlePanel("Using callR in Shiny"),
-  actionButton("start_job","Start Expensive Job"),
-  tableOutput('result_table')
+  actionButton("start_job", "Start Expensive Job"),
+  tableOutput("result_table")
 )
 
 server <- function(input, output, session) {
@@ -14,7 +14,7 @@ server <- function(input, output, session) {
   result <- reactiveValues(data = NULL)
   
   # set whatever arguments you want to use
-  some_argument <- 'virginica'
+  some_argument <- "virginica"
   
   # callR demonstration
   observeEvent(input$start_job, {
@@ -52,12 +52,10 @@ server <- function(input, output, session) {
       invalidateLater(millis = 1000)
       
       # do something while waiting
-      print(paste0('Still busy at ', Sys.time()))
       
       # whenever the background job is finished the value of is_alive() will be FALSE
       if (result$data$is_alive() == FALSE) {
         
-        print('Finished!')
         
         check_finished$value <- FALSE
         
@@ -65,6 +63,8 @@ server <- function(input, output, session) {
         
       }
       
+      print(paste0("Still busy at ", Sys.time()))
+        print("Finished!")
     }
     
   })

--- a/callr/callr_example.R
+++ b/callr/callr_example.R
@@ -52,7 +52,7 @@ server <- function(input, output, session) {
   # think about doing an expensive calculation and showing preliminary results
   observe({
     
-    if (check_finished$value == TRUE) {
+    req(check_finished())
       
       invalidateLater(millis = 1000)
       
@@ -70,7 +70,6 @@ server <- function(input, output, session) {
       
       print(paste0("Still busy at ", Sys.time()))
         print("Finished!")
-    }
     
   })
 

--- a/callr/callr_example.R
+++ b/callr/callr_example.R
@@ -53,23 +53,27 @@ server <- function(input, output, session) {
   observe({
     
     req(check_finished())
+    
+    invalidateLater(millis = 1000)
+    
+    # do something while waiting
+    print(paste0("Still busy at ", Sys.time()))
+    
+    p <- isolate(bg_proc())
+    
+    # whenever the background job is finished the value of is_alive() will be FALSE
+    if (p$is_alive() == FALSE) {
       
-      invalidateLater(millis = 1000)
+      print("Finished!")
       
-      # do something while waiting
+      check_finished(FALSE)
+      bg_proc(NULL)
       
-      # whenever the background job is finished the value of is_alive() will be FALSE
-      if (result$data$is_alive() == FALSE) {
-        
-        
-        check_finished$value <- FALSE
-        
-        output$result_table <- renderTable(result$data$get_result())
-        
-      }
+      # update the table data with results
+      # (do not nest setting `output` directly in observe methods)
+      table_dt(p$get_result())
       
-      print(paste0("Still busy at ", Sys.time()))
-        print("Finished!")
+    }
     
   })
 

--- a/callr/callr_example.R
+++ b/callr/callr_example.R
@@ -10,15 +10,16 @@ ui <- fluidPage(
 server <- function(input, output, session) {
   
   # initiate reactive values
-  check_finished <- reactiveValues(value = FALSE)
-  result <- reactiveValues(data = NULL)
+  bg_proc <- reactiveVal(NULL)
+  check_finished <- reactiveVal(FALSE)
   
   # set whatever arguments you want to use
   some_argument <- "virginica"
   
   # callR demonstration
   observeEvent(input$start_job, {
-    result$data <-
+    
+    p <-
       
       r_bg(
         
@@ -40,7 +41,9 @@ server <- function(input, output, session) {
         
       )
     
-    check_finished$value <- TRUE 
+    # update reactive vals
+    bg_proc(p)
+    check_finished(TRUE)
   })
   
   # this part can be useful if you want to update your UI during the process

--- a/callr/callr_example_rmd.R
+++ b/callr/callr_example_rmd.R
@@ -39,7 +39,7 @@ server <- function(input, output, session) {
       invalidateLater(millis = 1000)
       
       # do something while waiting
-      print(paste0('Still busy at ', Sys.time()))
+      print(paste0("Still busy at ", Sys.time()))
       
       # Make sure that you read out the stdout and stderr. I.e. you need to call $read_output() and $read_error()
       # See this issue: https://github.com/r-lib/callr/issues/204
@@ -49,14 +49,14 @@ server <- function(input, output, session) {
       # whenever the background job is finished the value of is_alive() will be FALSE
       if (result$outcome$is_alive() == FALSE) {
         
-        print('Finished!')
+        print("Finished!")
         
         check_finished$value <- FALSE
         
         # simulate a click on the download button, to trigger the actual download
         shinyjs::runjs("document.getElementById('download_doc_2').click();")
         
-        output$success_message <- renderText('Ready 🚀')
+        output$success_message <- renderText("Ready 🚀")
         
       }
       
@@ -70,10 +70,10 @@ server <- function(input, output, session) {
     # case we don't have write permissions to the current working dir (which
     # can happen when deployed).
     # this also makes the file available to the callR background process
-    temp_report_in <- file.path(tempdir(), paste0(as.integer(Sys.time()), '-markdown-doc.Rmd'))
+    temp_report_in <- file.path(tempdir(), paste0(as.integer(Sys.time()), "-markdown-doc.Rmd"))
     file.copy("./markdown-doc.Rmd", temp_report_in, overwrite = TRUE)
     
-    temp_report_out <- file.path(tempdir(), paste0(as.integer(Sys.time()), '-markdown-doc.pdf'))
+    temp_report_out <- file.path(tempdir(), paste0(as.integer(Sys.time()), "-markdown-doc.pdf"))
     
     # used in the downloadHandler
     result$report_location <- temp_report_out
@@ -100,7 +100,7 @@ server <- function(input, output, session) {
                               params = my_params
             )
             
-            return('finished')
+            return("finished")
             
           },
         
@@ -117,11 +117,11 @@ server <- function(input, output, session) {
   # this gets triggered by the JS click event
   output$download_doc_2 <- downloadHandler(
     
-    filename <- function() {
-      'markdown-doc.pdf'
+    filename = function() {
+      "markdown-doc.pdf"
     },
     
-    content <- function(file) {
+    content = function(file) {
       # copy the file from the temporary location that we set in result$report_location
       file.copy(result$report_location, file)
     }
@@ -131,4 +131,3 @@ server <- function(input, output, session) {
 }
 
 shinyApp(ui = ui, server = server)
-


### PR DESCRIPTION
Most changes are cosmetic. 

Only _real_ change is moving the `renderText()` outside the `observe()` call. `{reactlog}` and the garbage collector will be happy to work less.  Please let me know if I should submit a minimal PR with only this change. 