### PR TITLE
Gotftid/promises numeric n

### DIFF
--- a/promises/promises_cross_session_example.R
+++ b/promises/promises_cross_session_example.R
@@ -1,4 +1,4 @@
-
+library(shiny)
 library(promises)
 library(future)
 

--- a/promises/promises_cross_session_example.R
+++ b/promises/promises_cross_session_example.R
@@ -46,7 +46,7 @@ server <- function(input, output, session) {
     # reactive values and reactive expressions cannot be read from
     # within a future, therefore, you need to read any reactive
     # values/expressions in advance of launching the future
-    rows <- input$rows
+    rows <- as.numeric(input$rows)
     
     future_promise({
       # long computation

--- a/promises/promises_inner_session_example.R
+++ b/promises/promises_inner_session_example.R
@@ -1,4 +1,4 @@
-
+library(shiny)
 library(promises)
 library(future)
 

--- a/promises/promises_inner_session_example.R
+++ b/promises/promises_inner_session_example.R
@@ -46,7 +46,7 @@ server <- function(input, output, session) {
     # reactive values and reactive expressions cannot be read from
     # within a future, therefore, you need to read any reactive
     # values/expressions in advance of launching the future
-    rows <- input$rows
+    rows <- as.numeric(input$rows)
 
     future_promise({
       # long computation


### PR DESCRIPTION
### What happened?
Both examples in the promises folder throw the same error:

```
invalid 'n' - must be numeric, possibly NA.
```

### Solution
I suggest to make number of rows explicitly numeric to fix this - also won't hurt even if it works as is on some other setup.

Apart from that I added `library(shiny)` calls to make examples self-contained (looks like these lines were initially there but were removed by accident).

### Session info

```
R version 4.3.0 (2023-04-21)
Platform: aarch64-apple-darwin22.4.0 (64-bit)
Running under: macOS Ventura 13.4.1

Matrix products: default
BLAS:   /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib 
LAPACK: /opt/homebrew/Cellar/r/4.3.0_1/lib/R/lib/libRlapack.dylib;  LAPACK version 3.11.0

locale:
[1] en_US.UTF-8/en_US.UTF-8/en_US.UTF-8/C/en_US.UTF-8/en_US.UTF-8

time zone: Europe/Belgrade
tzcode source: internal

attached base packages:
[1] stats     graphics  grDevices datasets  utils     methods   base     

other attached packages:
[1] shiny_1.7.4      future_1.32.0    promises_1.2.0.1

loaded via a namespace (and not attached):
 [1] crayon_1.5.2      cli_3.6.1         rlang_1.1.1       renv_0.17.3       jsonlite_1.8.5    xtable_1.8-4      listenv_0.9.0    
 [8] htmltools_0.5.5   httpuv_1.6.11     sass_0.4.6        jquerylib_0.1.4   ellipsis_0.3.2    fontawesome_0.5.1 fastmap_1.1.1    
[15] lifecycle_1.0.3   memoise_2.0.1     compiler_4.3.0    codetools_0.2-19  Rcpp_1.0.10       later_1.3.1       digest_0.6.31    
[22] R6_2.5.1          parallelly_1.36.0 parallel_4.3.0    magrittr_2.0.3    bslib_0.5.0       tools_4.3.0       mime_0.12        
[29] globals_0.16.2    cachem_1.0.8     
```