### PR TITLE
mirai ExtendedTask Example Improvement

### DIFF
--- a/mirai/mirai_extendedtask.R
+++ b/mirai/mirai_extendedtask.R
@@ -80,8 +80,7 @@ server <- function(input, output, session) {
     reactive_status("Running 🏃")
     stock_results$invoke(symbol = input$company, 
                          start_date = input$dates[1], 
-                         end_date = input$dates[2],
-                         run = run_task)
+                         end_date = input$dates[2])
   })
   
   observeEvent(stock_results$result(), {
@@ -97,12 +96,15 @@ app <- shinyApp(ui = ui, server = server)
 with(
   daemons(4),
   {
-    # pre-load packages on all workers
-    everywhere({
-      library("ggplot2")
-      library("jsonlite")
-      library("httr")
-    })
+    # pre-load packages and helper function on all workers
+    everywhere(
+      {
+        library("ggplot2")
+        library("jsonlite")
+        library("httr")
+      },
+      run = run_task
+    )
     runApp(app)
   }
 )


### PR DESCRIPTION
Just one improvement to the example, and that is to pre-load the helper function initially in the `everywhere()` call.

As it remains constant for all invocations, it does not need to be passed each time.

I think this serves as a good example for similar usage.

Thanks!